### PR TITLE
Add handler for systemd restart.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -37,3 +37,7 @@
 - name: restart concourse-worker macosx
   shell: launchctl stop {{ concourseci_launchd_worker }} && launchctl start {{ concourseci_launchd_worker }}
   when: "groups[concourseci_worker_group] is defined and inventory_hostname in groups[concourseci_worker_group] and ansible_system == 'Darwin'"
+
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: ansible_service_mgr == "systemd"

--- a/tasks/web_nix.yml
+++ b/tasks/web_nix.yml
@@ -64,6 +64,7 @@
     dest="/etc/init.d/concourse-web"
     mode=0755
   notify:
+   - reload systemd
    - restart concourse-web
   when: "{{ ansible_system == 'Linux' }}"
 

--- a/tasks/worker_nix.yml
+++ b/tasks/worker_nix.yml
@@ -61,6 +61,7 @@
     dest="/etc/init.d/concourse-worker"
     mode=0755
   notify:
+   - reload systemd
    - restart concourse-worker
   when: "{{ ansible_system == 'Linux' }}"
 


### PR DESCRIPTION
See https://github.com/ansible/ansible-modules-core/issues/191 and https://lookonmyworks.co.uk/2015/06/24/ansible-systemctl-daemon-reload/. It's not clear that users of this playbook would have the most up to date ansible, so added an explicit handler.