### PR TITLE
Add basic logrotation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ concourseci_ssh_dir                         : "{{ concourseci_base_dir }}/.ssh"
 concourseci_log_dir                         : "/var/log/concourse"
 concourseci_log_worker                      : "{{ concourseci_log_dir }}/concourseci_worker.log"
 concourseci_log_web                         : "{{ concourseci_log_dir }}/concourseci_web.log"
+concourseci_log_rotate                      : True
 
 ## Concourse User
 concourseci_user                            : "concourseci"

--- a/tasks/common_nix.yml
+++ b/tasks/common_nix.yml
@@ -30,3 +30,9 @@
     mode=0750
     owner="{{ concourseci_user }}"
     group="{{ concourseci_group }}"
+
+- name: common | Ensure basic logrotation
+  template:
+    dest: /etc/logrotate.d/concourse
+    src: logrotate-concourse.j2
+  when: concourseci_log_rotate

--- a/templates/logrotate-concourse.j2
+++ b/templates/logrotate-concourse.j2
@@ -1,0 +1,9 @@
+{{ concourseci_log_dir }}/*.log {
+        size 100M
+        copytruncate
+        missingok
+        rotate 3
+        compress
+        notifempty
+        nocreate
+}


### PR DESCRIPTION
Hi! Thanks for this role, it works nicely. 

Logging to one ever-increasing file by default is not optimal, so can I suggest a basic log rotation? If you prefer, the `concourseci_log_rotate` could also be set to False by default in case it clashes with the way you handle logs. 