### PR TITLE
Fix default dictionary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ concourse_web_options                        : { }
 
 concourse_web_options_default                :
   CONCOURSE_BIND_IP                          : "0.0.0.0"
-  CONCOURSE_TSA_HOST                         : "{{ groups[concourseci_web_group][0] }}" # By default we pick the first host in web group
+  CONCOURSE_TSA_HOST                         : "{{ groups[concourseci_web_group][0] | default('') }}" # By default we pick the first host in web group
   CONCOURSE_TSA_BIND_IP                      : "0.0.0.0"
   CONCOURSE_TSA_BIND_PORT                    : "2222"
   CONCOURSE_TSA_AUTHORIZED_KEYS              : "{{ concourseci_ssh_dir }}/tsa_authorization"


### PR DESCRIPTION
Ansible fails trying to evaluate `groups[concourseci_web_group][0]`, e.g. when using Packer to create immutable worker AMI and there is no inventory file. This option has to be set manually, but Ansible will fail before combining default and user variables.