### PR TITLE
Don't assume groups[concourseci_web_group] exist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ concourse_web_options                        : { }
 
 concourse_web_options_default                :
   CONCOURSE_BIND_IP                          : "0.0.0.0"
-  CONCOURSE_TSA_HOST                         : "{{ groups[concourseci_web_group][0] | default('') }}" # By default we pick the first host in web group
+  CONCOURSE_TSA_HOST                         : "{{ groups.get(concourseci_web_group, [''])[0] }}" # By default we pick the first host in web group
   CONCOURSE_TSA_BIND_IP                      : "0.0.0.0"
   CONCOURSE_TSA_BIND_PORT                    : "2222"
   CONCOURSE_TSA_AUTHORIZED_KEYS              : "{{ concourseci_ssh_dir }}/tsa_authorization"


### PR DESCRIPTION
Current code fails if there are no hosts in the concourseci_web_group (when e.g. applying this playbook only to worker hosts). This holds true even if specifying a `concourse_web_options/CONCOURSE_TSA_HOST`. This change gives a default list with one element as the second argument to `.get`