### PR TITLE
Add support of concourse v3.10.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Concourse version
-concourseci_version                         : "v3.9.2"
+concourseci_version                         : "v3.10.0"
 
 ## Dir structure
 concourseci_base_dir                        : "/opt/concourseci"

--- a/templates/concourse-worker-init.sh.j2
+++ b/templates/concourse-worker-init.sh.j2
@@ -23,8 +23,12 @@ RUN_CMD="{{ concourseci_bin_dir }}/concourse-worker"
 
 ## Retire config
 export CONCOURSE_NAME="{{ concourse_worker_options_combined['CONCOURSE_NAME'] | default('$(hostname)') }}"
-export CONCOURSE_TSA_HOST="{{ concourse_web_options_combined['CONCOURSE_TSA_HOST'] }}"
-export CONCOURSE_TSA_PORT="{{ concourse_web_options_combined['CONCOURSE_TSA_PORT'] | default('2222') }}"
+{% if concourseci_version | version_compare('v3.10.0', '<') %}
+export CONCOURSE_TSA_HOST="{{ concourse_worker_options_combined['CONCOURSE_TSA_HOST'] }}"
+export CONCOURSE_TSA_PORT="{{ concourse_worker_options_combined['CONCOURSE_TSA_PORT'] }}"
+{% else %}
+export CONCOURSE_TSA_HOST="{{ concourse_worker_options_combined['CONCOURSE_TSA_HOST'] }}:{{ concourse_worker_options_combined['CONCOURSE_TSA_PORT'] }}"
+{% endif %}
 export CONCOURSE_TSA_PUBLIC_KEY="{{ concourse_worker_options_combined['CONCOURSE_TSA_HOST_KEY'] }}.pub"
 export CONCOURSE_TSA_WORKER_PRIVATE_KEY="{{ concourse_worker_options_combined['CONCOURSE_TSA_WORKER_PRIVATE_KEY'] }}"
 

--- a/templates/concourse-worker-init.sh.j2
+++ b/templates/concourse-worker-init.sh.j2
@@ -20,7 +20,6 @@ BASE_DIR="{{ concourseci_bin_dir }}"
 GREP_NAME="{{ concourseci_bin_dir }}/concourse worker"
 
 RUN_CMD="{{ concourseci_bin_dir }}/concourse-worker"
-RETIRE_CMD="{{ concourseci_bin_dir }}/concourse-worker-retire"
 
 ## Retire config
 export CONCOURSE_NAME="{{ concourse_worker_options_combined['CONCOURSE_NAME'] | default('$(hostname)') }}"

--- a/templates/concourse-worker.j2
+++ b/templates/concourse-worker.j2
@@ -3,7 +3,12 @@
 
 # Config
 {% for option, value in concourse_worker_options_combined.items() %}
+{% if (concourseci_version | version_compare('v3.10.0', '>=')) and option == 'CONCOURSE_TSA_HOST' %}
+export {{ option }}="{{ value }}:{{ concourse_worker_options_combined['CONCOURSE_TSA_PORT'] }}"
+{% elif (concourseci_version | version_compare('v3.10.0', '>=')) and option == 'CONCOURSE_TSA_PORT' %}
+{% else %}
 export {{ option }}="{{ value }}"
+{% endif %}
 {% endfor %}
 
 echo "" >> {{ concourseci_log_worker }}


### PR DESCRIPTION
Workaround this breaking change ([see Changelog](https://concourse-ci.org/download.html#v3100)):
- The concourse worker commands can now be pointed at multiple TSA addresses, rather than one, so that it can retry against a random node each time. As part of this, we've removed the --tsa-port flag and changed --tsa-host to instead take a host:port.