### PR TITLE
Fix permission mode for .ssh dir

### DIFF
--- a/tasks/common_nix.yml
+++ b/tasks/common_nix.yml
@@ -30,6 +30,6 @@
   file:
     path: '{{ concourseci_ssh_dir }}'
     state: directory
-    mode: 488
+    mode: '0750'
     owner: '{{ concourseci_user }}'
     group: '{{ concourseci_group }}'


### PR DESCRIPTION
Change permission mode for .ssh dir back to `0755`.
It looks like it was changed in https://github.com/ahelal/ansible-concourse/pull/56/files#diff-e98e71acf79670e5113b06483e8fd91aR33 by mistake.