### PR TITLE
Don't exit immediately when an error occurs while retiring workers

### DIFF
--- a/templates/concourse-worker-init.sh.j2
+++ b/templates/concourse-worker-init.sh.j2
@@ -75,10 +75,10 @@ retire_worker(){
                 sleep ${SLEEP}
             fi
         else
-            log "Got an error while retiring ${CONCOURSE_NAME}"
+            log "Got an error while retiring ${CONCOURSE_NAME}. Logged it and trying again."
             cat "${temp_file}" >> "${CONCOURSE_LOG_FILE}"
             rm "${temp_file}"
-            return 1
+            return 124
         fi
     done
 


### PR DESCRIPTION
The `retire_initd_interface` function is called before starting a concourse worker.
This function in turn calls `retire_worker` in a loop for as long as specified.

Sometimes, the `retire-worker` action called by the function fails with an HTTP500 but work if you try again.

Currently, the `retire_worker` function returns and exit code of 1 which indicates to `retire_initd_interface` that an "unrecoverable" error occured making the startup process exit and concourse worker never starts up.

This PR changes this flow to make the function return an exit code of 124 making the calling function continue the loop, the next try will most likely work, and if it doesn't (for some reason refuses to retire), a new concourse worker can at least start successfully.