### PR TITLE
[rbac] add possibility to write a rbac config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,3 +93,6 @@ concourseci_key_worker_private              : "{{ concourseci_worker_keys[concou
 
 # temp solution to systemV issue and ansible :(
 concourse_ignore_errors                       : "{{ ansible_lsb['codename'] == 'xenial' | default(False)}}"
+
+concourse_web_rbac_config:
+  CONCOURSE_CONFIG_RBAC: "{{concourseci_base_dir}}/bin/rbac_config.yml"

--- a/tasks/common_nix.yml
+++ b/tasks/common_nix.yml
@@ -5,6 +5,11 @@
     concourse_web_options_combined: '{{ concourse_web_options_default | combine(concourse_web_options) | combine(concourse_facts_local_users) | combine(concourse_facts_main_users) }}'
   when: "groups[concourseci_web_group] is defined and inventory_hostname in groups[concourseci_web_group]"
 
+- name: common | Combine option for concourse_rbac
+  set_fact:
+    concourse_web_options_combined: '{{ concourse_web_options_combined | combine(concourse_web_rbac_config) }}'
+  when: "groups[concourseci_web_group] is defined and inventory_hostname in groups[concourseci_web_group] and concourse_rbac is defined"
+
 - name: common | Combine dictionary options (worker)
   set_fact:
     concourse_worker_options_combined: '{{ concourse_worker_options_default | combine(concourse_worker_options) }}'

--- a/tasks/web_nix.yml
+++ b/tasks/web_nix.yml
@@ -50,6 +50,17 @@
   notify:
    - restart concourse-web
 
+- name: web | Write RBAC_CONFIG
+  copy:
+    content: "{{ concourse_rbac | to_yaml }}"
+    dest: "{{ concourse_web_options_combined['CONCOURSE_CONFIG_RBAC'] }}"
+    mode: 0755
+    owner: "{{ concourseci_user }}"
+    group: "{{ concourseci_group }}"
+  when: "concourse_web_options_combined['CONCOURSE_CONFIG_RBAC'] is defined"
+  notify:
+   - restart concourse-web
+
 - name: web | Templating concourse web start init script (linux)
   template:
     src="concourse-web-init.sh.j2"


### PR DESCRIPTION
In order to update rbac config, this change will do the following : 
- Save the configuration file path in the web options when _concourse_rbac_ object is defined
- Write the configuration file from the _concourse_rbac_ object
- Restart concourse-web