### PR TITLE
Add ability to configure defaults for resource types

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,17 @@ concourse_worker_options_default             :
 concourseci_web_group                       : "concourse-web"
 concourseci_worker_group                    : "concourse-worker"
 
+## See docs https://concourse-ci.org/concourse-web.html#resource-defaults
+## The value will land into the YAML file as is - after the usual string
+## interpolation is done.
+## The location of the file can be overridden by setting the appropriate
+## environment variable for the Concourse web node(s), e.g.:
+##
+##   concourse_web_options:
+##     CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS: '/some/path/to/defaults.yml'
+##
+concourseci_web_resource_type_defaults      : { }
+
 ## Management
 concourseci_manage_url                      : "{{ concourse_web_options_combined['CONCOURSE_EXTERNAL_URL'] | default('http://127.0.0.1:8080') }}"
 

--- a/tasks/common_nix.yml
+++ b/tasks/common_nix.yml
@@ -1,8 +1,21 @@
 ---
 
+- name: common | Set default for 'CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS'
+  set_fact:
+    concourse_web_options_resource_type_defaults_file_path:
+      CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS: '{{ concourseci_base_dir }}/resource-type-defaults.yml'
+  when: "{{ concourseci_web_resource_type_defaults | dict2items | length > 0 }}"
+
 - name: common | Combine dictionary options (web)
   set_fact:
-    concourse_web_options_combined: '{{ concourse_web_options_default | combine(concourse_web_options) | combine(concourse_facts_local_users) | combine(concourse_facts_main_users) }}'
+    concourse_web_options_combined: >-
+      {{
+        concourse_web_options_default
+        | combine(concourse_web_options_resource_type_defaults_file_path | default({}))
+        | combine(concourse_web_options)
+        | combine(concourse_facts_local_users)
+        | combine(concourse_facts_main_users)
+      }}
   when: "groups[concourseci_web_group] is defined and inventory_hostname in groups[concourseci_web_group]"
 
 - name: common | Combine dictionary options (worker)

--- a/tasks/web_nix.yml
+++ b/tasks/web_nix.yml
@@ -85,3 +85,14 @@
   shell: launchctl load -w {{ concourseci_launchd_path }}/{{ concourseci_launchd_web }}.plist && launchctl start {{ concourseci_launchd_web }}
   changed_when: False # since no way to detect if it started or not
   when: "ansible_system == 'Darwin'"
+
+- name: web | Create base resource type defaults configuration file
+  copy:
+    owner: "{{ concourseci_user }}"
+    group: "{{ concourseci_group }}"
+    dest: "{{ concourse_web_options_combined['CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS'] }}"
+    content: "{{ concourseci_web_resource_type_defaults | to_nice_yaml(indent=2) }}"
+    mode: '644'
+  when: "{{ concourseci_web_resource_type_defaults | dict2items | length > 0 }}"
+  notify:
+   - restart concourse-web


### PR DESCRIPTION
In order to set resource type defaults, one may set the Ansible variable
'concourseci_web_resource_type_defaults'. The value of that variable will
be put into a YAML file - after the usual string interpolation has
happened. 
This would, for example, allow to [set a `registry-mirror`](https://github.com/concourse/concourse/releases/tag/v6.7.0):

```
vars:
  concourseci_web_resource_type_defaults:
    registry-image:
      registry_mirror:
        host: "192.168.1.12:5000"
    docker-image:
      registry_mirror: "http://192.168.1.12:5000"
```

The location of that file can be overridden by setting the appropriate
environment variable for the Concourse web node(s), e.g.:

```
concourse_web_options:
  CONCOURSE_BASE_RESOURCE_TYPE_DEFAULTS: '/some/path/to/defaults.yml'
```