### PR TITLE
Fixes #91

### DIFF
--- a/tasks/web_nix.yml
+++ b/tasks/web_nix.yml
@@ -76,7 +76,7 @@
     name="concourse-web"
     state="started"
     enabled=True
-  ignore_errors: "{{ concourse_ignore_errors }}"
+  ignore_errors: true
   when: "ansible_system == 'Linux'"
 
 - name: web | Templating concourse web start launchd plist (macOSx)
@@ -107,3 +107,11 @@
   when: "{{ concourseci_web_resource_type_defaults | dict2items | length > 0 }}"
   notify:
    - restart concourse-web
+
+- name: web | Ensure Concourse web is running and Starts on boot (linux)
+  service:
+    name="concourse-web"
+    state="started"
+    enabled=True
+  ignore_errors: "{{ concourse_ignore_errors }}"
+  when: "ansible_system == 'Linux'"


### PR DESCRIPTION
Ignoring errors on the first run allows the resource type file to be created, and the service check can be ran afterwards.